### PR TITLE
#170947555 notifications for new travel request.

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,4 @@
+{
+  "watch": ["src/"],
+  "ignore": ["src/services/localesServices/locales"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1731,9 +1731,9 @@
       }
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1949,9 +1949,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.1.1.tgz",
-      "integrity": "sha512-X5Dj8hK1pJNC2Wzo2Rcp9FBVdJMGRR/S7V+lH46s8GVFhtbo5O4Le5GECCF/8PISVdkUA6mMPvgz7qTTD1rf1g=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "async-each": {
       "version": "1.0.3",
@@ -3236,11 +3236,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
     },
     "electron-to-chromium": {
       "version": "1.3.345",
@@ -5822,6 +5817,13 @@
       "requires": {
         "ejs": "^2.6.1",
         "juice": "^5.2.0"
+      },
+      "dependencies": {
+        "ejs": {
+          "version": "2.7.4",
+          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+          "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA=="
+        }
       }
     },
     "make-dir": {
@@ -9273,9 +9275,9 @@
           "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
         },
         "htmlparser2": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.0.0.tgz",
-          "integrity": "sha512-cChwXn5Vam57fyXajDtPXL1wTYc8JtLbr2TN76FYu05itVVVealxLowe2B3IEznJG4p9HAYn/0tJaRlGuEglFQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
           "requires": {
             "domelementtype": "^2.0.1",
             "domhandler": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon --exec babel-node src/index.js",
     "build": "rm -rf ./dist && babel -d ./dist ./src",
     "test": "npm run db:reset --env test && npx sequelize db:seed:undo:all --env test && npm run seed --env test && npm run test:unit",
-    "test:unit": "NODE_ENV=test nyc --require @babel/register  mocha --recursive './src/**/*.test.js' --timeout 20000 --exit",
+    "test:unit": "NODE_ENV=test nyc --require @babel/register  mocha --recursive './src/**/*.test.js' --timeout 2000 --exit",
     "db:migrate": "npx sequelize db:migrate --env test",
     "db:reset": "npx sequelize db:migrate:undo:all --env test && npm run db:migrate --env test",
     "create": "npx sequelize db:migrate",

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,6 @@
                 background-color: #eee;
                 font-size: 25px;
                 text-align: center;
-
             }
             .notifs {
                 color: rgb(13, 13, 46);

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -53,7 +53,7 @@ export default class AuthController {
         lastName: lastName.toLowerCase(),
         email,
         password: hashedPassword,
-        role: 'requester'
+        role: 'requester',
       });
       const token = provideToken(user.id, user.isVerified, email, user.role);
       const link = `http://${process.env.BASE_URL}/api/v1/auth/verification?token=${token}&email=${email}`;

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -21,4 +21,36 @@ export default class notificationController {
       return Response.errorResponse(res, 500, res.__('server error'));
     }
   }
+
+  /**
+   * @param  {object} req
+   * @param  {object} res
+   * @param  {object} next
+   * @return {object} notification
+   */
+  static async optOutEmailNotifications(req, res) {
+    try {
+      const { user } = req;
+      await db.User.update({ emailNotifications: false }, { where: { id: user.id } });
+      return Response.success(res, 200, res.__('you have opted out of email notifications'));
+    } catch (error) {
+      return Response.errorResponse(res, 500, res.__('server error'));
+    }
+  }
+
+  /**
+   * @param  {object} req
+   * @param  {object} res
+   * @param  {object} next
+   * @return {object} notification
+   */
+  static async optInEmailNotifications(req, res) {
+    try {
+      const { user } = req;
+      await db.User.update({ emailNotifications: true }, { where: { id: user.id } });
+      return Response.success(res, 200, res.__('you have opted in for email notifications'));
+    } catch (error) {
+      return Response.errorResponse(res, 500, res.__('server error'));
+    }
+  }
 }

--- a/src/controllers/tripsController.js
+++ b/src/controllers/tripsController.js
@@ -22,6 +22,7 @@ export default class requestController {
   static async createRequest(req, res) {
     try {
       const { user } = req;
+
       const {
         location, destination, reason, departureDate, gender, role, passportName
       } = req.body;
@@ -51,6 +52,24 @@ export default class requestController {
           role
         }],
       });
+
+      const managerInfo = await db.User.findOne({ where: { id: user.managerId } });
+
+      const notification = await notifService.createNotif(
+        newRequest.managerId,
+        managerInfo.email,
+        `A trip request to ${newRequest.destination} on ${newRequest.departureDate} has been requested by ${user.firstName}, ${user.lastName}, it is waiting your approval.`,
+        '#'
+      );
+      const content = {
+        intro: `${req.__('A trip request to')} ${newRequest.destination} ${req.__('on')} ${newRequest.departureDate} ${req.__('has been requested by')} ${newRequest.profileData[0].passportName}`,
+        instruction: req.__('To view this open request, click below'),
+        text: req.__('View request'),
+        signature: req.__('signature')
+      };
+
+      await SendNotification.sendNotif(notification, req, content);
+
       return Response.success(res, 201, res.__('Request created successfully'), newRequest);
     } catch (error) {
       return Response.errorResponse(res, 500, error.message);
@@ -101,6 +120,24 @@ export default class requestController {
           role: role.toLowerCase().trim()
         }],
       });
+
+      const managerInfo = await db.User.findOne({ where: { id: user.managerId } });
+
+      const notification = await notifService.createNotif(
+        newRequest.managerId,
+        managerInfo.email,
+        `A trip request to ${newRequest.destination} on ${newRequest.departureDate} has been requested by ${user.firstName}, ${user.lastName}, it is waiting your approval.`,
+        '#'
+      );
+      const content = {
+        intro: `${req.__('A trip request to')} ${newRequest.destination} ${req.__('on')} ${newRequest.departureDate} ${req.__('has been requested by')} ${newRequest.profileData[0].passportName}`,
+        instruction: req.__('To view this open request, click below'),
+        text: req.__('View request'),
+        signature: req.__('signature')
+      };
+
+      await SendNotification.sendNotif(notification, req, content);
+
       return Response.success(res, 201, res.__('Request created successfully'), newRequest);
     } catch (err) {
       return Response.errorResponse(res, 500, err.message);
@@ -234,6 +271,24 @@ export default class requestController {
           role
         }],
       });
+
+      const managerInfo = await db.User.findOne({ where: { id: user.managerId } });
+
+      const notification = await notifService.createNotif(
+        newMulticityRequest.managerId,
+        managerInfo.email,
+        `A trip request to ${newMulticityRequest.destination} on ${newMulticityRequest.departureDate} has been requested by ${user.firstName}, ${user.lastName}, it is waiting your approval.`,
+        '#'
+      );
+      const content = {
+        intro: `${req.__('A trip request to')} ${newMulticityRequest.destination} ${req.__('on')} ${newMulticityRequest.departureDate} ${req.__('has been requested by')} ${newMulticityRequest.profileData[0].passportName}`,
+        instruction: req.__('To view this open request, click below'),
+        text: req.__('View request'),
+        signature: req.__('signature')
+      };
+
+      await SendNotification.sendNotif(notification, req, content);
+
       return Response.success(res, 201, res.__('Multi city request created successfully'), newMulticityRequest);
     } catch (error) {
       return Response.errorResponse(res, 500, error.message);

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ app.use((req, res, next) => {
   req.io = io;
   next();
 });
+
 app.use('/', welcome);
 app.use('/api-doc', swagger);
 app.use('/api/v1/auth', authRouter);

--- a/src/middlewares/protectRoute.js
+++ b/src/middlewares/protectRoute.js
@@ -19,6 +19,7 @@ export default class protectRoutes {
   static async verifyUser(req, res, next) {
     try {
       const { token } = req.headers;
+
       if (!token) {
         return Response.errorResponse(res, 401, res.__('No token provided'));
       }

--- a/src/migrations/20200209182554-create-user.js
+++ b/src/migrations/20200209182554-create-user.js
@@ -41,6 +41,11 @@ module.exports = {
         type: Sequelize.BOOLEAN,
         defaultValue: false
       },
+      emailNotifications: {
+        allowNull: false,
+        type: Sequelize.BOOLEAN,
+        defaultValue: true
+      },
       language: {
         type: Sequelize.STRING
       },

--- a/src/models/notifications.js
+++ b/src/models/notifications.js
@@ -9,6 +9,7 @@ module.exports = (sequelize, DataTypes) => {
   Notifications.associate = (models) => {
     Notifications.belongsTo(models.User, {
       foreignKey: 'receiverId',
+      as: 'user',
       onDelete: 'CASCADE'
     });
   };

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -16,7 +16,8 @@ module.exports = (sequelize, DataTypes) => {
     residence: DataTypes.STRING,
     birthdate: DataTypes.STRING,
     image: DataTypes.STRING,
-    isVerified: DataTypes.BOOLEAN
+    isVerified: DataTypes.BOOLEAN,
+    emailNotifications: DataTypes.BOOLEAN
   }, {});
   User.associate = (models) => {
     User.hasMany(models.Bookings, {

--- a/src/routes/notifications.js
+++ b/src/routes/notifications.js
@@ -6,5 +6,7 @@ import protectRoute from '../middlewares/protectRoute';
 const router = express.Router();
 
 router.patch('/all-read', protectRoute.verifyUser, protectRoute.checkUnreadNotifications, validationResult, notificationController.markAllNotificationsAsRead);
+router.patch('/email-opt-out', protectRoute.verifyUser, validationResult, notificationController.optOutEmailNotifications);
+router.patch('/email-opt-in', protectRoute.verifyUser, validationResult, notificationController.optInEmailNotifications);
 
 export default router;

--- a/src/routes/tripsRoutes.js
+++ b/src/routes/tripsRoutes.js
@@ -1,4 +1,3 @@
-
 import express from 'express';
 import tripsController from '../controllers/tripsController';
 import {

--- a/src/services/localesServices/locales/en.json
+++ b/src/services/localesServices/locales/en.json
@@ -115,7 +115,6 @@
 	"User does not exist or they are not a manager or they are both managers": "User does not exist or they are not a manager or they are both managers",
 	"Sorry, you are not authorized to access this page.": "Sorry, you are not authorized to access this page.",
 	"server error": "server error",
-	"Your trip to gisenyi on 2020-12-01 you requested has been rejected": "Your trip to gisenyi on 2020-12-01 you requested has been rejected",
 	"To view this rejected request you made click below": "To view this rejected request you made click below",
 	"the trip to": "the trip to",
 	"on": "on",
@@ -130,7 +129,6 @@
 	"To view this As a your manager I can add any comment on your request. I can also cancel or approve your request but let me comment first request you made click below": "To view this As a your manager I can add any comment on your request. I can also cancel or approve your request but let me comment first request you made click below",
 	"View comment": "View comment",
 	"To view this thanks for your comment manager. This is my request too. And please Approve my request after this comment request you made click below": "To view this thanks for your comment manager. This is my request too. And please Approve my request after this comment request you made click below",
-	"To view this yeahahaha 252525626262 request you made click below": "To view this yeahahaha 252525626262 request you made click below",
 	"As a your manager I can add any comment on your request. I can also cancel or approve your request but let me comment first": "As a your manager I can add any comment on your request. I can also cancel or approve your request but let me comment first",
 	"thanks for your comment manager. This is my request too. And please Approve my request after this comment": "thanks for your comment manager. This is my request too. And please Approve my request after this comment",
 	"your manager posted a comment": "your manager posted a comment",
@@ -140,5 +138,13 @@
 	"To view this %s click below": "To view this %s click below",
 	"Your Manager commented: %s": "Your Manager commented: %s",
 	"Your requsester commented: %s": "Your requsester commented: %s",
-	"Your requester commented: %s": "Your requester commented: %s"
+	"Your requester commented: %s": "Your requester commented: %s",
+	"To view this open request you made click below": "To view this open request you made click below",
+	"that you requested has been sent made by": "that you requested has been sent made by",
+	"To view this open request, click below": "To view this open request, click below",
+	"you have opted out of email notifications": "you have opted out of email notifications",
+	"you have opted in for email notifications": "you have opted in for email notifications",
+	"that you requested has been made by": "that you requested has been made by",
+	"A trip request to": "A trip request to",
+	"has been requested by": "has been requested by"
 }

--- a/src/services/localesServices/locales/fr.json
+++ b/src/services/localesServices/locales/fr.json
@@ -159,5 +159,10 @@
 	"your manager posted a comment: %s": "votre manager a posté un commentaire: %s",
 	"Your Manager commented: %s": "Votre demandeur a commenté: %s",
 	"View comment": "Afficher le commentaire",
-	"your manager posted a comment": "votre manager a posté un commentaire"
+	"your manager posted a comment": "votre manager a posté un commentaire",
+	"that you requested has been sent made by": "que vous avez demandé a été envoyé par",
+	"you have opted out of email notifications":"vous avez désactivé les notifications par e-mail",
+	"you have opted in for email notifications": "vous avez activé les notifications par e-mail",
+	"A trip request to": "Une demande de voyage à",
+	"has been requested by": "a été demandé par"
 }

--- a/src/swagger/notifications.swagger.js
+++ b/src/swagger/notifications.swagger.js
@@ -22,6 +22,49 @@
  *             description: Server Error.
  * */
 
+/**
+ * @swagger
+ * /api/v1/notifications/email-opt-out:
+ *   patch:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Notifications
+ *     name: optOutEmailNotifications
+ *     summary: enables a user to mark opt out for email notifications
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: token
+ *         in: header
+ *     responses:
+ *       '200':
+ *             description: you have opted out of email notifications.
+ *       '500':
+ *             description: Server Error.
+ * */
+
+/**
+ * @swagger
+ * /api/v1/notifications/email-opt-in:
+ *   patch:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Notifications
+ *     name: optInEmailNotifications
+ *     summary: enables a user to mark opt in for email notifications
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: token
+ *         in: header
+ *     responses:
+ *       '200':
+ *             description: you have opted in for email notifications.
+ *       '500':
+ *             description: Server Error.
+ * */
 
 /**
  * @swagger

--- a/src/tests/comments.test.js
+++ b/src/tests/comments.test.js
@@ -110,13 +110,13 @@ describe('COMMENTS TESTS', () => {
         expect(res.body.data.requestId).to.equal('51e74db7-5510-4f50-9f15-e23710331ld5');
         expect(res.body.data.commmentOwner).to.equal('0119b84a-99a4-41c0-8a0e-6e0b6c385165');
         expect(res.body.data.comment).to.equal('As a your manager I can add any comment on your request. I can also cancel or approve your request but let me comment first');
+        done();
       });
     clientSocket.on('notification', (msg) => {
       expect(JSON.parse(msg)).to.be.an('object');
       expect(JSON.parse(msg).receiverId).to.equal('79660e6f-4b7d-4g21-81re-74f54e9e1c8a');
       expect(JSON.parse(msg).status).to.equal('unread');
       expect(JSON.parse(msg).content).to.equal('your manager posted a comment');
-      done();
     });
   });
   it('should not allow a manager to comment on a request which does not belong to him', (done) => {

--- a/src/tests/editTrip.test.js
+++ b/src/tests/editTrip.test.js
@@ -43,7 +43,7 @@ describe('EDIT TRIP TESTS', () => {
   beforeEach((done) => {
     sinon.stub(sgMail, 'send').resolves({
       to: 'aime@amgil.com',
-      from: 'devrepublic.team@gmail.com',
+      from: 'devrepublic@gmail.com',
       subject: 'barefoot nomad',
       html: 'this is stubbing message'
     });
@@ -83,12 +83,12 @@ describe('EDIT TRIP TESTS', () => {
       .send(openRequest)
       .end((err, res) => {
         expect(res.status).to.equal(200);
+        done();
       });
     clientSocket.on('notification', (msg) => {
       expect(JSON.parse(msg)).to.be.an('object');
       expect(JSON.parse(msg).receiverId).to.equal('0119b84a-99a4-41c0-8a0e-6e0b6c385165');
       expect(JSON.parse(msg).status).to.equal('unread');
-      done();
     });
   });
   it('should return trip does not exist or has been approved or rejected', (done) => {

--- a/src/tests/likeUnlike.test.js
+++ b/src/tests/likeUnlike.test.js
@@ -22,6 +22,17 @@ describe('LIKE/DISLIKE TESTS', () => {
         done();
       });
   });
+  it('should return user has unliked the facility', (done) => {
+    chai
+      .request(app)
+      .patch('/api/v1/facilities/unlike?id=5be72db7-5510-4a50-9f15-e23f103116d5')
+      .set('token', token)
+      .end((err, res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.message).to.equal('user has unliked facility');
+        done();
+      });
+  });
   it('should return user has liked the facility', (done) => {
     chai
       .request(app)

--- a/src/tests/reconfirmRequest.test.js
+++ b/src/tests/reconfirmRequest.test.js
@@ -18,10 +18,10 @@ let otherManagerToken;
 describe('re-confirm request tests', () => {
   let clientSocket;
   const BASE_URL = `http://localhost:${server.address().port}`;
-  beforeEach((done) => {
+  beforeEach(() => {
     sinon.stub(sgMail, 'send').resolves({
       to: 'aime@amgil.com',
-      from: 'devrepublic.team@gmail.com',
+      from: 'devrepublic@gmail.com',
       subject: 'barefoot nomad',
       html: 'this is stubbing message'
     });
@@ -32,13 +32,12 @@ describe('re-confirm request tests', () => {
       },
       'force new connection': true,
     });
-
-    done();
+    // done();
   });
-  afterEach((done) => {
+  afterEach(() => {
     clientSocket.disconnect();
     sinon.restore();
-    done();
+    // done();
   });
 
   before((done) => {
@@ -137,12 +136,12 @@ describe('re-confirm request tests', () => {
       .end((err, res) => {
         expect(res.status).to.equal(200);
         expect(res.body.message).to.equal('request re-confirmed');
+        done();
       });
     clientSocket.on('notification', (data) => {
       expect(JSON.parse(data)).to.be.an('object');
       expect(JSON.parse(data).receiverId).to.equal('79660e6f-4b7d-4g21-81re-74f54jk91c8a');
       expect(JSON.parse(data).content).to.equal('the trip to gisenyi on 2020-12-01 that you requested has been rejected');
-      done();
     });
   });
 });

--- a/src/tests/returnTrips.test.js
+++ b/src/tests/returnTrips.test.js
@@ -1,5 +1,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import sgMail from '@sendgrid/mail';
 import index from '../index';
 import { provideToken } from '../utils/tokenHandler';
 
@@ -12,6 +14,17 @@ let noManagerToken;
 
 const notSignupToken = provideToken('dewdwwdwd', false, 'ade@gmail.com');
 describe('CREATE A RETURN TRIP', () => {
+  beforeEach(() => {
+    sinon.stub(sgMail, 'send').resolves({
+      to: 'aime@amgil.com',
+      from: 'devrepublic@gmail.com',
+      subject: 'barefoot nomad',
+      html: 'this is stubbing message'
+    });
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
   before((done) => {
     const loggedUser = {
       email: 'jeannette@andela.com',

--- a/src/tests/trips.test.js
+++ b/src/tests/trips.test.js
@@ -1,5 +1,7 @@
 import chai from 'chai';
 import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import sgMail from '@sendgrid/mail';
 import app from '../index';
 
 const {
@@ -86,6 +88,17 @@ const validDatesMulticityRequest = {
 chai.use(chaiHttp);
 
 describe('REQUEST TRIP TESTS', () => {
+  beforeEach(() => {
+    sinon.stub(sgMail, 'send').resolves({
+      to: 'aime@amgil.com',
+      from: 'devrepublic@gmail.com',
+      subject: 'barefoot nomad',
+      html: 'this is stubbing message'
+    });
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
   before((done) => {
     chai
       .request(app)

--- a/src/utils/ResponseHandler.js
+++ b/src/utils/ResponseHandler.js
@@ -10,27 +10,27 @@ export default class ResponceHandler {
  *
  *
  * @static
- * @param {Object} response
+ * @param {Object} res
  * @param {Object} status
  * @param {String} message
  * @param {Object} token
  * @returns {Object} token
  * @memberof ResponceHandler
  */
-  static signupResponse(response, status, message, token) {
-    return (response.status(status).json({ status, message, token, }));
+  static signupResponse(res, status, message, token) {
+    return (res.status(status).json({ status, message, token, }));
   }
 
   /**
  * @static
- * @param {Object} response
+ * @param {Object} res
  * @param {Object} status
  * @param {String} error
  * @returns {Object} error
  * @memberof ResponceHandler
  */
-  static errorResponse(response, status, error) {
-    return (response.status(status).json({ status, error }));
+  static errorResponse(res, status, error) {
+    return (res.status(status).json({ status, error }));
   }
 
   /**


### PR DESCRIPTION
#### What does this PR do?
add a `Managers should be able to get a notification for a new travel request made` feature

#### Description of Task to be completed?
- Add emailNotification option column in the users table
- Add condition to check if user is signed up of email notification in related controllers
- Use the sendNotification utility and socketio middleware to inApp and email notifications.
- Set up functionality to opt out of the email notification service.

#### How should this be manually tested?
- clone this repo
- run npm install to install all dependencies
- run the server (npm run reset:dev)
- create a new user by making a post request at `/api/v1/auth/register` (you can use your email to get notifications)
- login in the super admin to assign that yourself the role of a manager
- super admin: `jean@andela.com`, password: `Bien@BAR789`
- assign yourself a subordinate among the seeded users or create a new requester, then use patch request at `/api/v1/users/assign/manager` (check how to assign a manager in it's PR.)
- login as that user
- make a post request to `/api/v1/trips/return` or `/api/v1/trips/one-way`
- you will get an email and an inApp notification for that user.
- to view the notifications, login the manager you created
- use this link `/api/v1/notifications/` to view the inApp notifications 

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#170947555](https://www.pivotaltracker.com/story/show/170947555)

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30793016/76426026-2a685d80-63b3-11ea-975b-bfe4b1d14d4c.png)
![image](https://user-images.githubusercontent.com/30793016/76426038-2e947b00-63b3-11ea-8f07-140244433931.png)

#### Questions:
- N/A