### PR TITLE
#170947577 user provide feedback

### DIFF
--- a/src/controllers/facilitiesController.js
+++ b/src/controllers/facilitiesController.js
@@ -214,5 +214,25 @@ class FacilitiesController {
       return Response.errorResponse(res, 500, err.message);
     }
   }
+
+  /**
+* @description give a facility feedback
+* @static
+* @param {Object} req
+* @param {Object} res
+* @returns {Object} Facility feedback
+* @memberof FacilitiesController
+*/
+  static async facilityFeedback(req, res) {
+    const { facilityId } = req.params;
+    const { user } = req;
+    const { feedback } = req.body;
+    try {
+      const result = await FacilityService.feedback(facilityId, user, feedback);
+      return (((result === stringHelper.facilityNotFound) && Response.errorResponse(res, 404, req.__(result))) || ((result === stringHelper.notVisitedFacility) && Response.errorResponse(res, 403, req.__(result))) || (typeof result === 'object' && Response.success(res, 201, req.__('feedback saved successfully'), result)));
+    } catch (err) {
+      return Response.errorResponse(res, 500, err.message);
+    }
+  }
 }
 export default FacilitiesController;

--- a/src/migrations/20200317161145-create-feedback.js
+++ b/src/migrations/20200317161145-create-feedback.js
@@ -1,0 +1,44 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.createTable('Feedbacks', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.STRING
+      },
+      facilityId: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        references:{
+          model: 'Facilities',
+          key: 'id'
+        }
+      },
+      userId: {
+        type: Sequelize.STRING,
+        allowNull: false,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE',
+        references:{
+          model: 'Users',
+          key: 'id'
+        }
+      },
+      feedback: {
+        type: Sequelize.TEXT,
+        allowNull: false
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.dropTable('Feedbacks');
+  }
+};

--- a/src/models/feedback.js
+++ b/src/models/feedback.js
@@ -1,0 +1,20 @@
+module.exports = (sequelize, DataTypes) => {
+  const Feedback = sequelize.define('Feedback', {
+    facilityId: DataTypes.STRING,
+    userId: DataTypes.STRING,
+    feedback: DataTypes.TEXT
+  }, {});
+  Feedback.associate = (models) => {
+    Feedback.belongsTo(models.User, {
+      foreignKey: 'userId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+    Feedback.belongsTo(models.Facilities, {
+      foreignKey: 'facilityId',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+  };
+  return Feedback;
+};

--- a/src/routes/facilityRoute.js
+++ b/src/routes/facilityRoute.js
@@ -1,7 +1,12 @@
 import express from 'express';
 import FacilitiesController from '../controllers/facilitiesController';
 import protectRoute from '../middlewares/protectRoute';
-import { createFacilityRules, bookingRules, rateQueryRules } from '../validation/validationRules';
+import {
+  createFacilityRules,
+  bookingRules,
+  rateQueryRules,
+  feedbackRules
+} from '../validation/validationRules';
 import validationResult from '../validation/validationResult';
 import { multerUploads } from '../utils/multer';
 import alreadyLiked from '../utils/alreadyLiked';
@@ -15,5 +20,6 @@ router.patch('/like', protectRoute.verifyUser, protectRoute.verifyFacility, prot
 router.patch('/unlike', protectRoute.verifyUser, protectRoute.verifyFacility, protectRoute.checkIfUnliked, alreadyLiked, FacilitiesController.unlikeFacility);
 router.post('/book', protectRoute.verifyUser, protectRoute.verifyRequester, bookingRules, validationResult, FacilitiesController.bookFacility);
 router.patch('/rate/:facilityId', protectRoute.verifyUser, rateQueryRules, validationResult, FacilitiesController.rateFacility);
+router.post('/feedback/:facilityId', protectRoute.verifyUser, protectRoute.verifyRequester, feedbackRules, validationResult, FacilitiesController.facilityFeedback);
 
 export default router;

--- a/src/services/facilityService.js
+++ b/src/services/facilityService.js
@@ -55,4 +55,37 @@ export default class FacilityService {
     });
     return updatedFacility;
   }
+
+  /**
+   * @param  {Object} facilityId
+   * @param  {Object} user
+   * @param  {Object} feedback
+   * @returns {Object} NewFeedback
+   */
+  static async feedback(facilityId, user, feedback) {
+    const todayDate = new Date();
+    const facility = await db.Facilities.findByPk(facilityId);
+    if (!facility) {
+      return stringHelper.facilityNotFound;
+    }
+    const booking = await db.Bookings.findOne({
+      where: {
+        bookedBy: user.email,
+        facilityId,
+        checkin: {
+          [Sequelize.Op.lte]: todayDate
+        }
+      }
+    });
+    if (!booking) {
+      return stringHelper.notVisitedFacility;
+    }
+    const newFeedback = await db.Feedback.create({
+      id: uuid(),
+      feedback,
+      facilityId,
+      userId: user.id
+    });
+    return newFeedback;
+  }
 }

--- a/src/services/localesServices/locales/en.json
+++ b/src/services/localesServices/locales/en.json
@@ -171,5 +171,8 @@
 	"Requests not found": "Requests not found",
 	"Request not found or not yours to approve": "Request not found or not yours to approve",
 	"Trips statistics": "Trips statistics",
-	"Request not found or not yours to manage": "Request not found or not yours to manage"
+	"Request not found or not yours to manage": "Request not found or not yours to manage",
+	"feedback is required": "feedback is required",
+	"feedback can't be longer than 300 character": "feedback can't be longer than 300 character",
+	"feedback saved successfully" : "feedback saved successfully"
 }

--- a/src/services/localesServices/locales/fr.json
+++ b/src/services/localesServices/locales/fr.json
@@ -178,5 +178,8 @@
 	"Requests not found": "Demandes non trouvées",
 	"Request found": "Demande trouvée",
 	"Request not found or not yours to approve": "Demande d'approbation introuvable ou non à vous",
-	"Trips statistics": "Statistiques de voyages"
+	"Trips statistics": "Statistiques de voyages",
+	"feedback is required": "une rétroaction est requise",
+	"feedback can't be longer than 300 character": "les commentaires ne peuvent pas dépasser 300 caractères",
+	"feedback saved successfully" : "commentaires enregistrés avec succès"
 }

--- a/src/swagger/facilities.swagger.js
+++ b/src/swagger/facilities.swagger.js
@@ -235,3 +235,40 @@
  *       '400':
  *             description: the rating can only be an integer number less or equal to 5
  * */
+
+/**
+ * @swagger
+ * /api/v1/facilities/feedback/{facilityId}:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     tags:
+ *       - Facilities
+ *     name: give feedback to a facilility
+ *     summary: a user can provide feedback to a facility they visited
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - name: token
+ *         in: header
+ *       - name: facilityId
+ *         in: path
+ *       - name: body
+ *         in: body
+ *         schema:
+ *           type: object
+ *           properties:
+ *             feedback:
+ *               type: string
+ *         required:
+ *           - feedback
+ *     responses:
+ *       '200':
+ *             description: feedback saved successfully
+ *       '404':
+ *             description: facility not found
+ *       '403':
+ *             description: you haven't visited this facility yet
+ * */

--- a/src/tests/unitTests/facilityService.test.js
+++ b/src/tests/unitTests/facilityService.test.js
@@ -59,3 +59,48 @@ describe('RATE A FACILITY SERVICE TEST', () => {
     expect(result.averageRating).to.equal(4);
   });
 });
+describe('GIVE FEEDBACK SERVICE TEST', () => {
+  const user = {
+    id: '79660e6f-4b7d-4g21-81re-74f54jk91c8a',
+    firstName: 'devrepubli',
+    lastName: 'devrpo',
+    email: 'jdev@andela.com',
+    role: 'requester',
+    managerId: '0119b84a-99a4-41c0-8a0e-6e0b6c385165',
+  };
+  const feedback = 'can you add green tea to your breakfast menu';
+  beforeEach(() => {
+    sinon.stub(db.Bookings, 'findOne').resolves({
+      id: 'd1d6c6d3-92b3-4000-9f8e-70981c49dc6e',
+      roomId: '47d21452-ea54-4f2a-a1df-2c167c34cdd2',
+      facilityId: '5be72db7-5510-4a50-9f15-e23f103116d5',
+      checkin: '2020-06-11',
+      checkout: '2019-10-10',
+      requestId: '51e74db7-5510-4f50-9f15-e23710331ld5',
+      bookedBy: 'jdev@andela.com',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+  });
+  afterEach(() => {
+    sinon.restore();
+  });
+  it('should return a string if the facility is not found', async () => {
+    const facilityId = '5be72db7-5510-4a50-9f15-e23f103116d3';
+    const result = await facilityService.feedback(facilityId, user, feedback);
+    expect(result).to.equal('facility not found');
+  });
+  it('should return a string if a booking with a checkin less than today is not found', async () => {
+    sinon.reset();
+    const facilityId = '5bb72db7-5514-4a50-9g15-e23f103116d3';
+    const result = await facilityService.feedback(facilityId, user, feedback);
+    expect(result).to.equal('you haven\'t visited this facility yet');
+  });
+  it('should save the feedback', async () => {
+    const facilityId = '5be72db7-5510-4a50-9f15-e23f103116d5';
+    const result = await facilityService.feedback(facilityId, user, feedback);
+    expect(result).to.be.an('object');
+    expect(result.feedback).to.equal(feedback);
+    expect(result.facilityId).to.equal(facilityId);
+  });
+});

--- a/src/validation/validationRules.js
+++ b/src/validation/validationRules.js
@@ -149,3 +149,11 @@ export const rateQueryRules = [
     .isInt({ min: 1, max: 5 })
     .withMessage('the rating can only be an integer number less or equal to 5')
 ];
+export const feedbackRules = [
+  check('feedback').not()
+    .isEmpty({ ignore_whitespace: true })
+    .withMessage('feedback is required')
+    .bail()
+    .isLength({ min: 1, max: 300 })
+    .withMessage('feedback can\'t be longer than 300 character')
+];


### PR DESCRIPTION
#### What does this PR do?
Adds a feature that allows a requester to provide feedback to the facilities they visited.
#### Description of Task to be completed?
- add the feedback controller
- add the Feedback table
- add test for the feature
- add internalization for the different response
- document the feature with swagger
#### How should this be manually tested?
- clone this repo `https://github.com/andela/devrepublic-bn-backend.git`
- run `npm install`
- run `npm run reset:dev`
- go to your browser
- open swagger documentation
- send a post request `api/v1/facilities/feedback/:facilityId
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[ #170947577](https://www.pivotaltracker.com/n/projects/2431451/stories/170947577)
#### Screenshots (if appropriate)
#### Questions:
<img width="708" alt="Screen Shot 2020-03-17 at 20 08 44" src="https://user-images.githubusercontent.com/51261911/76887742-6146e380-688b-11ea-80df-0a0041c9139f.png">
<img width="741" alt="Screen Shot 2020-03-17 at 20 09 23" src="https://user-images.githubusercontent.com/51261911/76887771-6b68e200-688b-11ea-8bf4-ce8f20e30ee5.png">
<img width="582" alt="Screen Shot 2020-03-17 at 20 09 40" src="https://user-images.githubusercontent.com/51261911/76887796-7459b380-688b-11ea-866a-01b12f4c1940.png">
<img width="907" alt="Screen Shot 2020-03-17 at 20 10 13" src="https://user-images.githubusercontent.com/51261911/76887809-7cb1ee80-688b-11ea-80ea-9c21301f61e5.png">
